### PR TITLE
Remove unused import.

### DIFF
--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -1,6 +1,5 @@
 import { content, element, subexpr, lookupHelper } from "ember-htmlbars/hooks";
 import { DOMHelper } from "morph";
-import Stream from "ember-metal/streams/stream";
 
 import { bindHelper } from "ember-htmlbars/helpers";
 


### PR DESCRIPTION
This is causing us to fail JSHint.
