### PR TITLE
Update HTMLBars helper registration.

### DIFF
--- a/packages/ember-htmlbars/lib/helpers.js
+++ b/packages/ember-htmlbars/lib/helpers.js
@@ -1,50 +1,81 @@
 /**
 @module ember
-@submodule ember-handlebars
+@submodule ember-htmlbars
 */
 
-import run from "ember-metal/run_loop";
+import View from "ember-views/views/view";
+import Component from "ember-views/views/component";
+import makeViewHelper from "./helpers/make-view-helper";
 
-/*
-import {
-  bind,
-  exists
-} from "ember-handlebars/helpers/binding";
+var helpers = { };
+
+/**
+  Register a bound helper or custom view helper.
+
+  ## Simple bound helper example
+
+  ```javascript
+  Ember.HTMLBars.helper('capitalize', function(value) {
+    return value.toUpperCase();
+  });
+  ```
+
+  The above bound helper can be used inside of templates as follows:
+
+  ```handlebars
+  {{capitalize name}}
+  ```
+
+  In this case, when the `name` property of the template's context changes,
+  the rendered value of the helper will update to reflect this change.
+
+  For more examples of bound helpers, see documentation for
+  `Ember.HTMLBars.registerBoundHelper`.
+
+  ## Custom view helper example
+
+  Assuming a view subclass named `App.CalendarView` were defined, a helper
+  for rendering instances of this view could be registered as follows:
+
+  ```javascript
+  Ember.HTMLBars.helper('calendar', App.CalendarView):
+  ```
+
+  The above bound helper can be used inside of templates as follows:
+
+  ```handlebars
+  {{calendar}}
+  ```
+
+  Which is functionally equivalent to:
+
+  ```handlebars
+  {{view 'calendar'}}
+  ```
+
+  Options in the helper will be passed to the view in exactly the same
+  manner as with the `view` helper.
+
+  @method helper
+  @for Ember.HTMLBars
+  @param {String} name
+  @param {Function|Ember.View} function or view class constructor
+  @param {String} dependentKeys*
 */
+export function helper(name, value) {
+  Ember.assert("You tried to register a component named '" + name +
+               "', but component names must include a '-'", !Component.detect(value) || name.match(/-/));
 
-import {
-  SimpleHandlebarsView
-} from "ember-handlebars/views/handlebars_bound_view";
-
-function simpleBind(params, options, env) {
-  var parentView = env.data.view;
-  var lazyValue = params[0];
-
-  var view = new SimpleHandlebarsView(
-    lazyValue, options.escaped
-  );
-
-  view._parentView = parentView;
-  view._morph = options.morph;
-  parentView.appendChild(view);
-
-  lazyValue.subscribe(parentView._wrapAsScheduled(function() {
-    run.scheduleOnce('render', view, 'rerender');
-  }));
-}
-
-function bindHelper(params, options, env) {
-  if (options.fn) {
-    // This code path has not been tested at all
-    // TODO: is this needed?
-    // options.helperName = 'bind';
-    // bind.call(options.context, property, options, false, exists);
-    throw new Error("not implemented");
+  if (View.detect(value)) {
+    registerHelper(name, makeViewHelper(value));
   } else {
-    simpleBind(params, options, env);
+    // HTMLBars TODO: Support bound helpers
+    // EmberHandlebars.registerBoundHelper.apply(null, arguments);
   }
 }
 
-export {
-  bindHelper
-};
+export function registerHelper(name, value) {
+  helpers[name] = value;
+}
+
+export default helpers;

--- a/packages/ember-htmlbars/lib/helpers/bind.js
+++ b/packages/ember-htmlbars/lib/helpers/bind.js
@@ -1,0 +1,39 @@
+/**
+@module ember
+@submodule ember-htmlbars
+*/
+
+import run from "ember-metal/run_loop";
+
+import {
+  SimpleHandlebarsView
+} from "ember-handlebars/views/handlebars_bound_view";
+
+function simpleBind(params, options, env) {
+  var parentView = env.data.view;
+  var lazyValue = params[0];
+
+  var view = new SimpleHandlebarsView(
+    lazyValue, options.escaped
+  );
+
+  view._parentView = parentView;
+  view._morph = options.morph;
+  parentView.appendChild(view);
+
+  lazyValue.subscribe(parentView._wrapAsScheduled(function() {
+    run.scheduleOnce('render', view, 'rerender');
+  }));
+}
+
+export default function bindHelper(params, options, env) {
+  if (options.fn) {
+    // This code path has not been tested at all
+    // TODO: is this needed?
+    // options.helperName = 'bind';
+    // bind.call(options.context, property, options, false, exists);
+    throw new Error("not implemented");
+  } else {
+    simpleBind(params, options, env);
+  }
+}

--- a/packages/ember-htmlbars/lib/helpers/make-view-helper.js
+++ b/packages/ember-htmlbars/lib/helpers/make-view-helper.js
@@ -1,0 +1,22 @@
+import Ember from "ember-metal/core"; // Ember.assert
+import viewHelper from "ember-htmlbars/helpers/view";
+
+/**
+  Returns a helper function that renders the provided ViewClass.
+
+  Used internally by Ember.Handlebars.helper and other methods
+  involving helper/component registration.
+
+  @private
+  @method makeViewHelper
+  @param {Function} ViewClass view class constructor
+  @since 1.2.0
+*/
+export default function makeViewHelper(ViewClass) {
+  return function(params, options, env) {
+    Ember.assert("You can only pass attributes (such as name=value) not bare " +
+                 "values to a helper for a View found in '" + ViewClass.toString() + "'", params.length === 0);
+
+    return viewHelper.call(this, [ViewClass], options, env);
+  };
+}

--- a/packages/ember-htmlbars/lib/helpers/view.js
+++ b/packages/ember-htmlbars/lib/helpers/view.js
@@ -352,7 +352,7 @@ export var ViewHelper = EmberObject.create({
   @param {Hash} options
   @return {String} HTML string
 */
-export function viewHelper(params, options, env) {
+export default function viewHelper(params, options, env) {
   Ember.assert("The view helper only takes a single argument", params.length <= 2);
 
   var container = this.container || this._keywords.view.value().container;

--- a/packages/ember-htmlbars/lib/helpers/yield.js
+++ b/packages/ember-htmlbars/lib/helpers/yield.js
@@ -90,7 +90,7 @@ import { get } from "ember-metal/property_get";
   @param {Hash} options
   @return {String} HTML string
 */
-export function yieldHelper(params, options, env) {
+export default function yieldHelper(params, options, env) {
   var view = this;
 
   // Yea gods

--- a/packages/ember-htmlbars/lib/hooks.js
+++ b/packages/ember-htmlbars/lib/hooks.js
@@ -26,7 +26,7 @@ export function content(morph, path, view, params, options, env) {
   morph.escaped = options.escaped;
   var helper = hooks.lookupHelper(path, env);
   if (!helper) {
-    helper = hooks.lookupHelper('bindHelper', env);
+    helper = hooks.lookupHelper('bind', env);
     // Modify params to include the first word
     params.unshift(path);
     options.types = ['id'];

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -1,9 +1,18 @@
 import { content, element, subexpr, lookupHelper } from "ember-htmlbars/hooks";
 import { DOMHelper } from "morph";
 
-import { bindHelper } from "ember-htmlbars/helpers";
-import { viewHelper } from "ember-htmlbars/helpers/view";
-import { yieldHelper } from "ember-htmlbars/helpers/yield";
+import {
+  registerHelper,
+  default as helpers
+} from "ember-htmlbars/helpers";
+
+import yieldHelper from "ember-htmlbars/helpers/yield";
+import viewHelper from "ember-htmlbars/helpers/view";
+import bindHelper from "ember-htmlbars/helpers/bind";
+
+registerHelper('yield', yieldHelper);
+registerHelper('view', viewHelper);
+registerHelper('bind', bindHelper);
 
 export var defaultEnv = {
   dom: new DOMHelper(),
@@ -15,10 +24,6 @@ export var defaultEnv = {
     lookupHelper: lookupHelper
   },
 
-  helpers: {
-    bindHelper: bindHelper,
-    view: viewHelper,
-    'yield': yieldHelper
-  }
+  helpers: helpers
 };
 

--- a/packages/ember-htmlbars/tests/helpers/yield_test.js
+++ b/packages/ember-htmlbars/tests/helpers/yield_test.js
@@ -1,14 +1,18 @@
 /*jshint newcap:false*/
 import run from "ember-metal/run_loop";
 import EmberView from "ember-views/views/view";
-import {computed} from "ember-metal/computed";
+// import {computed} from "ember-metal/computed";
 import Container from "ember-runtime/system/container";
-import { get } from "ember-metal/property_get";
+// import { get } from "ember-metal/property_get";
 import { set } from "ember-metal/property_set";
-import { A } from "ember-runtime/system/native_array";
+// import { A } from "ember-runtime/system/native_array";
 import Component from "ember-views/views/component";
 import EmberError from "ember-metal/error";
 import { compile } from "htmlbars-compiler/compiler";
+import {
+  helper,
+  default as helpers
+} from "ember-htmlbars/helpers";
 
 var view, container;
 
@@ -330,7 +334,6 @@ test("yield should work for views even if _parentView is null", function() {
 
 });
 
-/* needs-helper-registration
 QUnit.module("ember-htmlbars: Component {{yield}}", {
   setup: function() {},
   teardown: function() {
@@ -338,11 +341,27 @@ QUnit.module("ember-htmlbars: Component {{yield}}", {
       if (view) {
         view.destroy();
       }
-      delete EmberHandlebars.helpers['inner-component'];
-      delete EmberHandlebars.helpers['outer-component'];
+      delete helpers['inner-component'];
+      delete helpers['outer-component'];
     });
   }
 });
+
+/* HTMLBars TODO: throws an error
+
+// Error: Assertion Failed: A fragment cannot be pushed into a buffer that contains content
+//     at new Error (native)
+//     at Error.EmberError (http://localhost:5200/ember.js:14521:23)
+//     at Object.Ember.assert (http://localhost:5200/ember.js:3914:15)
+//     at Object._RenderBuffer.push (http://localhost:5200/ember.js:40530:17)
+//     at CoreView.extend.render (http://localhost:5200/ember.js:43748:46)
+//     at EmberRenderer_createElement [as createElement] (http://localhost:5200/ember.js:40886:16)
+//     at EmberRenderer.Renderer_renderTree [as renderTree] (http://localhost:5200/ember.js:10910:24)
+//     at EmberRenderer.scheduledRenderTree (http://localhost:5200/ember.js:10987:16)
+//     at Queue.invoke (http://localhost:5200/ember.js:840:18)
+//     at Object.Queue.flush (http://localhost:5200/ember.js:905:13)
+
+*/
 
 test("yield with nested components (#3220)", function(){
   var count = 0;
@@ -355,13 +374,13 @@ test("yield with nested components (#3220)", function(){
     }
   });
 
-  EmberHandlebars.helper('inner-component', InnerComponent);
+  helper('inner-component', InnerComponent);
 
   var OuterComponent = Component.extend({
     layout: compile("{{#inner-component}}<span>{{yield}}</span>{{/inner-component}}")
   });
 
-  EmberHandlebars.helper('outer-component', OuterComponent);
+  helper('outer-component', OuterComponent);
 
   view = EmberView.create({
     template: compile(
@@ -411,6 +430,5 @@ test("view keyword works inside component yield", function () {
 
   equal(view.$('div > p').text(), "hello", "view keyword inside component yield block should refer to the correct view");
 });
-*/
 
 }


### PR DESCRIPTION
Refactors helpers and helper registration.
- Move `bind` helper into separate module (and rename from `bindHelper` to `bind`).
- `makeViewHelper`
- `helper`
- `registerHelper`

Nested component yield test throws an error still:

```
A fragment cannot be pushed into a buffer that contains content
```
