### PR TITLE
Helper recomputation must trigger rerender

### DIFF
--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -1002,7 +1002,6 @@ Application.reopenClass({
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { singleton: false });
 
     registry.register('application:main', namespace, { instantiate: false });
 

--- a/packages/ember-application/lib/system/application.js
+++ b/packages/ember-application/lib/system/application.js
@@ -1002,7 +1002,7 @@ Application.reopenClass({
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
 
     registry.register('application:main', namespace, { instantiate: false });
 

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -364,7 +364,7 @@ export default EmberObject.extend({
   */
   resolveHelper(parsedName) {
     var resolved = this.resolveOther(parsedName) || helpers[parsedName.fullNameWithoutType];
-    if (resolved && !resolved.isHelperFactory && typeof resolved === 'function') {
+    if (resolved && !resolved.isHelperFactory && !resolved.isHelperInstance && !resolved.isHTMLBars && typeof resolved === 'function') {
       resolved = new HandlebarsCompatibleHelper(resolved);
     }
     return resolved;

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -364,8 +364,8 @@ export default EmberObject.extend({
   */
   resolveHelper(parsedName) {
     var resolved = this.resolveOther(parsedName) || helpers[parsedName.fullNameWithoutType];
-    if (resolved && !resolved.isHelper && typeof resolved === 'function') {
-      resolved = new HandlebarsCompatibleHelper(helper);
+    if (resolved && !resolved.isHelperFactory && typeof resolved === 'function') {
+      resolved = new HandlebarsCompatibleHelper(resolved);
     }
     return resolved;
   },

--- a/packages/ember-application/lib/system/resolver.js
+++ b/packages/ember-application/lib/system/resolver.js
@@ -15,6 +15,7 @@ import EmberObject from 'ember-runtime/system/object';
 import Namespace from 'ember-runtime/system/namespace';
 import helpers from 'ember-htmlbars/helpers';
 import validateType from 'ember-application/utils/validate-type';
+import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 
 export var Resolver = EmberObject.extend({
   /**
@@ -362,7 +363,11 @@ export default EmberObject.extend({
     @method resolveHelper
   */
   resolveHelper(parsedName) {
-    return this.resolveOther(parsedName) || helpers[parsedName.fullNameWithoutType];
+    var resolved = this.resolveOther(parsedName) || helpers[parsedName.fullNameWithoutType];
+    if (resolved && !resolved.isHelper && typeof resolved === 'function') {
+      resolved = new HandlebarsCompatibleHelper(helper);
+    }
+    return resolved;
   },
   /**
     Look up the specified object (from parsedName) on the appropriate

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -113,11 +113,12 @@ QUnit.test("the default resolver resolves container-registered helpers", functio
   application.register('helper:shorthand', shorthandHelper);
   application.register('helper:complete', helper);
 
-  let lookedUpShorthandHelper = locator.lookup('helper:shorthand');
-  ok(lookedUpShorthandHelper.isHelper, 'shorthand helper isHelper');
+  let lookedUpShorthandHelper = locator.lookupFactory('helper:shorthand');
+  ok(lookedUpShorthandHelper.isHelperInstance, 'shorthand helper isHelper');
 
-  let lookedUpHelper = locator.lookup('helper:complete');
-  ok(helper.detectInstance(lookedUpHelper), "looked up complete helper is instantiated");
+  let lookedUpHelper = locator.lookupFactory('helper:complete');
+  ok(lookedUpHelper.isHelperFactory, 'complete helper is factory');
+  ok(helper.detect(lookedUpHelper), "looked up complete helper");
 });
 
 QUnit.test("the default resolver resolves helpers on the namespace", function() {

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -107,7 +107,7 @@ QUnit.test("the default resolver resolves helpers", function() {
 });
 
 QUnit.test("the default resolver resolves container-registered helpers", function() {
-  let shorthandHelper = Helper.build(() => {});
+  let shorthandHelper = Helper.build(function() {});
   let helper = Helper.extend();
 
   application.register('helper:shorthand', shorthandHelper);
@@ -121,12 +121,12 @@ QUnit.test("the default resolver resolves container-registered helpers", functio
 });
 
 QUnit.test("the default resolver resolves helpers on the namespace", function() {
-  let ShorthandHelper = Helper.build(() => {});
+  let ShorthandHelper = Helper.build(function() {});
   let CompleteHelper = Helper.extend();
-  let LegacyBareFunctionHelper = () => {};
-  let LegacyHandlebarsBoundHelper = makeHandlebarsBoundHelper(() => {});
-  let LegacyHTMLBarsBoundHelper = makeHTMLBarsBoundHelper(() => {});
-  let ViewHelper = makeViewHelper(() => {});
+  let LegacyBareFunctionHelper = function() {};
+  let LegacyHandlebarsBoundHelper = makeHandlebarsBoundHelper(function() {});
+  let LegacyHTMLBarsBoundHelper = makeHTMLBarsBoundHelper(function() {});
+  let ViewHelper = makeViewHelper(function() {});
 
   application.ShorthandHelper = ShorthandHelper;
   application.CompleteHelper = CompleteHelper;

--- a/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
+++ b/packages/ember-application/tests/system/dependency_injection/default_resolver_test.js
@@ -9,6 +9,11 @@ import Service from "ember-runtime/system/service";
 import EmberObject from "ember-runtime/system/object";
 import Namespace from "ember-runtime/system/namespace";
 import Application from "ember-application/system/application";
+import Helper from "ember-htmlbars/helper";
+import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
+import makeHandlebarsBoundHelper from "ember-htmlbars/compat/make-bound-helper";
+import makeViewHelper from "ember-htmlbars/system/make-view-helper";
+import makeHTMLBarsBoundHelper from "ember-htmlbars/system/make_bound_helper";
 import {
   registerHelper
 } from "ember-htmlbars/helpers";
@@ -102,12 +107,47 @@ QUnit.test("the default resolver resolves helpers", function() {
 });
 
 QUnit.test("the default resolver resolves container-registered helpers", function() {
-  function gooresolvertestHelper() { return 'GOO'; }
-  function gooGazResolverTestHelper() { return 'GAZ'; }
-  application.register('helper:gooresolvertest', gooresolvertestHelper);
-  application.register('helper:goo-baz-resolver-test', gooGazResolverTestHelper);
-  equal(gooresolvertestHelper, locator.lookup('helper:gooresolvertest'), "looks up gooresolvertest helper");
-  equal(gooGazResolverTestHelper, locator.lookup('helper:goo-baz-resolver-test'), "looks up gooGazResolverTestHelper helper");
+  let shorthandHelper = Helper.build(() => {});
+  let helper = Helper.extend();
+
+  application.register('helper:shorthand', shorthandHelper);
+  application.register('helper:complete', helper);
+
+  let lookedUpShorthandHelper = locator.lookup('helper:shorthand');
+  ok(lookedUpShorthandHelper.isHelper, 'shorthand helper isHelper');
+
+  let lookedUpHelper = locator.lookup('helper:complete');
+  ok(helper.detectInstance(lookedUpHelper), "looked up complete helper is instantiated");
+});
+
+QUnit.test("the default resolver resolves helpers on the namespace", function() {
+  let ShorthandHelper = Helper.build(() => {});
+  let CompleteHelper = Helper.extend();
+  let LegacyBareFunctionHelper = () => {};
+  let LegacyHandlebarsBoundHelper = makeHandlebarsBoundHelper(() => {});
+  let LegacyHTMLBarsBoundHelper = makeHTMLBarsBoundHelper(() => {});
+  let ViewHelper = makeViewHelper(() => {});
+
+  application.ShorthandHelper = ShorthandHelper;
+  application.CompleteHelper = CompleteHelper;
+  application.LegacyBareFunctionHelper = LegacyBareFunctionHelper;
+  application.LegacyHandlebarsBoundHelper = LegacyHandlebarsBoundHelper;
+  application.LegacyHtmlBarsBoundHelper = LegacyHTMLBarsBoundHelper; // Must use lowered "tml" in "HTMLBars" for resolver to find this
+  application.ViewHelper = ViewHelper;
+
+  let resolvedShorthand = registry.resolve('helper:shorthand');
+  let resolvedComplete = registry.resolve('helper:complete');
+  let resolvedLegacy = registry.resolve('helper:legacy-bare-function');
+  let resolvedLegacyHandlebars = registry.resolve('helper:legacy-handlebars-bound');
+  let resolvedLegacyHTMLBars = registry.resolve('helper:legacy-html-bars-bound');
+  let resolvedView = registry.resolve('helper:view');
+
+  equal(resolvedShorthand, ShorthandHelper, 'resolve fetches the shorthand helper factory');
+  equal(resolvedComplete, CompleteHelper, 'resolve fetches the complete helper factory');
+  ok(resolvedLegacy instanceof HandlebarsCompatibleHelper, 'legacy function helper is wrapped in HandlebarsCompatibleHelper');
+  equal(resolvedView, ViewHelper, 'resolves view helper');
+  equal(resolvedLegacyHTMLBars, LegacyHTMLBarsBoundHelper, 'resolves legacy HTMLBars bound helper');
+  equal(resolvedLegacyHandlebars, LegacyHandlebarsBoundHelper, 'resolves legacy Handlebars bound helper');
 });
 
 QUnit.test("the default resolver throws an error if the fullName to resolve is invalid", function() {

--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -108,12 +108,8 @@ function HandlebarsCompatibleHelper(fn) {
 
 HandlebarsCompatibleHelper.prototype = {
   preprocessArguments() { },
-  create() {
-    return this;
-  },
-  extend() {
-    return this;
-  },
+  isHelperFactory: true,
+  create() { return this; },
   reopenClass() {}
 };
 

--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -108,8 +108,6 @@ function HandlebarsCompatibleHelper(fn) {
 
 HandlebarsCompatibleHelper.prototype = {
   preprocessArguments() { },
-  isHelperFactory: true,
-  create() { return this; },
   reopenClass() {}
 };
 

--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -107,8 +107,7 @@ function HandlebarsCompatibleHelper(fn) {
 }
 
 HandlebarsCompatibleHelper.prototype = {
-  preprocessArguments() { },
-  reopenClass() {}
+  preprocessArguments() { }
 };
 
 export function registerHandlebarsCompatibleHelper(name, value) {

--- a/packages/ember-htmlbars/lib/compat/helper.js
+++ b/packages/ember-htmlbars/lib/compat/helper.js
@@ -107,7 +107,14 @@ function HandlebarsCompatibleHelper(fn) {
 }
 
 HandlebarsCompatibleHelper.prototype = {
-  preprocessArguments() { }
+  preprocessArguments() { },
+  create() {
+    return this;
+  },
+  extend() {
+    return this;
+  },
+  reopenClass() {}
 };
 
 export function registerHandlebarsCompatibleHelper(name, value) {

--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -64,8 +64,8 @@ export default function makeBoundHelper(fn, ...dependentKeys) {
       return fn.apply(undefined, args);
     },
 
+    isHelperFactory: true,
     create() { return this },
-    extend() { return this },
     reopenClass() {}
   };
 }

--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -62,6 +62,10 @@ export default function makeBoundHelper(fn, ...dependentKeys) {
 
       args.push({ hash: readHash(hash) , templates, data: { properties } });
       return fn.apply(undefined, args);
-    }
+    },
+
+    create() { return this },
+    extend() { return this },
+    reopenClass() {}
   };
 }

--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -65,7 +65,7 @@ export default function makeBoundHelper(fn, ...dependentKeys) {
     },
 
     isHelperFactory: true,
-    create() { return this },
+    create() { return this; },
     reopenClass() {}
   };
 }

--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -64,8 +64,6 @@ export default function makeBoundHelper(fn, ...dependentKeys) {
       return fn.apply(undefined, args);
     },
 
-    isHelperFactory: true,
-    create() { return this; },
     reopenClass() {}
   };
 }

--- a/packages/ember-htmlbars/lib/compat/make-bound-helper.js
+++ b/packages/ember-htmlbars/lib/compat/make-bound-helper.js
@@ -62,8 +62,6 @@ export default function makeBoundHelper(fn, ...dependentKeys) {
 
       args.push({ hash: readHash(hash) , templates, data: { properties } });
       return fn.apply(undefined, args);
-    },
-
-    reopenClass() {}
+    }
   };
 }

--- a/packages/ember-htmlbars/lib/helper.js
+++ b/packages/ember-htmlbars/lib/helper.js
@@ -1,5 +1,6 @@
 import Object from "ember-runtime/system/object";
 
+// Ember.Helper.extend({ compute(params, hash) {} });
 var Helper = Object.extend({
   isHelper: true,
   recompute() {
@@ -7,8 +8,7 @@ var Helper = Object.extend({
   }
 });
 
-// Ember.Helper.build(function(params, hash) {
-// });
+// Ember.Helper.build(function(params, hash) {});
 Helper.reopenClass({
   isHelperFactory: true,
   build(helperFn) {

--- a/packages/ember-htmlbars/lib/helper.js
+++ b/packages/ember-htmlbars/lib/helper.js
@@ -13,13 +13,8 @@ Helper.reopenClass({
   isHelperFactory: true,
   build(helperFn) {
     return {
-      isHelperFactory: true,
-      create() {
-        return {
-          isHelper: true,
-          compute: helperFn
-        };
-      }
+      isHelperInstance: true,
+      compute: helperFn
     };
   }
 });

--- a/packages/ember-htmlbars/lib/helper.js
+++ b/packages/ember-htmlbars/lib/helper.js
@@ -7,6 +7,8 @@ var Helper = Object.extend({
   }
 });
 
+// Ember.Helper.build(function(params, hash) {
+// });
 Helper.reopenClass({
   isHelperFactory: true,
   build(helperFn) {

--- a/packages/ember-htmlbars/lib/helper.js
+++ b/packages/ember-htmlbars/lib/helper.js
@@ -5,6 +5,7 @@ var Helper = Object.extend({
   isHelper: true,
   recompute() {
     this._stream.notify();
+    this._view.rerender();
   }
 });
 

--- a/packages/ember-htmlbars/lib/helper.js
+++ b/packages/ember-htmlbars/lib/helper.js
@@ -33,6 +33,7 @@ Helper.reopenClass({
   isHelperFactory: true,
   build(helperFn) {
     return {
+      isHelperFactory: true,
       create() {
         return {
           isHelper: true,

--- a/packages/ember-htmlbars/lib/helper.js
+++ b/packages/ember-htmlbars/lib/helper.js
@@ -1,0 +1,49 @@
+import Object from "ember-runtime/system/object";
+import merge from "ember-metal/merge";
+import Stream from "ember-metal/streams/stream";
+import create from "ember-metal/platform/create";
+
+function HelperStream(helper, params, hash,label) {
+  this.init(label);
+  this.helper = helper;
+  this.params = params;
+  this.hash = hash;
+}
+
+HelperStream.prototype = create(Stream.prototype);
+
+merge(HelperStream.prototype, {
+  compute() {
+    return this.helper.compute(this.params, this.hash);
+  }
+});
+
+var Helper = Object.extend({
+  isHelper: true,
+  recompute() {
+    this._stream.notify();
+  },
+  getStream(params, hash) {
+    this._stream = new HelperStream(this, params, hash);
+    return this._stream;
+  },
+});
+
+Helper.reopenClass({
+  isHelperFactory: true,
+  build(helperFn) {
+    return {
+      create() {
+        return {
+          isHelper: true,
+          getStream(params, hash) {
+            return new HelperStream(this, params, hash);
+          },
+          compute: helperFn
+        };
+      }
+    };
+  }
+});
+
+export default Helper;

--- a/packages/ember-htmlbars/lib/helper.js
+++ b/packages/ember-htmlbars/lib/helper.js
@@ -1,32 +1,10 @@
 import Object from "ember-runtime/system/object";
-import merge from "ember-metal/merge";
-import Stream from "ember-metal/streams/stream";
-import create from "ember-metal/platform/create";
-
-function HelperStream(helper, params, hash,label) {
-  this.init(label);
-  this.helper = helper;
-  this.params = params;
-  this.hash = hash;
-}
-
-HelperStream.prototype = create(Stream.prototype);
-
-merge(HelperStream.prototype, {
-  compute() {
-    return this.helper.compute(this.params, this.hash);
-  }
-});
 
 var Helper = Object.extend({
   isHelper: true,
   recompute() {
     this._stream.notify();
-  },
-  getStream(params, hash) {
-    this._stream = new HelperStream(this, params, hash);
-    return this._stream;
-  },
+  }
 });
 
 Helper.reopenClass({
@@ -37,9 +15,6 @@ Helper.reopenClass({
       create() {
         return {
           isHelper: true,
-          getStream(params, hash) {
-            return new HelperStream(this, params, hash);
-          },
           compute: helperFn
         };
       }

--- a/packages/ember-htmlbars/lib/hooks/element.js
+++ b/packages/ember-htmlbars/lib/hooks/element.js
@@ -5,6 +5,7 @@
 
 import { findHelper } from "ember-htmlbars/system/lookup-helper";
 import { handleRedirect } from "htmlbars-runtime/hooks";
+import { buildHelperStream } from "ember-htmlbars/system/invoke-helper";
 
 var fakeElement;
 
@@ -32,7 +33,8 @@ export default function emberElement(morph, env, scope, path, params, hash, visi
   var result;
   var helper = findHelper(path, scope.self, env);
   if (helper) {
-    result = env.hooks.invokeHelper(null, env, scope, null, params, hash, helper, { element: morph.element }).value;
+    var helperStream = buildHelperStream(helper, params, hash, { element: morph.element }, env, scope);
+    result = helperStream.value();
   } else {
     result = env.hooks.get(env, scope, path);
   }

--- a/packages/ember-htmlbars/lib/hooks/has-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/has-helper.js
@@ -11,15 +11,6 @@ export default function hasHelperHook(env, scope, helperName) {
     if (container._registry.has(containerName)) {
       return true;
     }
-
-    var componentLookup = container.lookup('component-lookup:main');
-    Ember.assert("Could not find 'component-lookup:main' on the provided container," +
-                 " which is necessary for performing component lookups", componentLookup);
-
-    if (container._registry.has('component:' + path) ||
-        container._registry.has('template:components/' + path)) {
-      return true;
-    }
   }
 
   return false;

--- a/packages/ember-htmlbars/lib/hooks/has-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/has-helper.js
@@ -1,5 +1,26 @@
-import { findHelper } from "ember-htmlbars/system/lookup-helper";
+import { validateLazyHelperName } from "ember-htmlbars/system/lookup-helper";
 
 export default function hasHelperHook(env, scope, helperName) {
-  return !!findHelper(helperName, scope.self, env);
+  if (env.helpers[helperName]) {
+    return true;
+  }
+
+  var container = env.container;
+  if (validateLazyHelperName(helperName, container, env.hooks.keywords)) {
+    var containerName = 'helper:' + helperName;
+    if (container._registry.has(containerName)) {
+      return true;
+    }
+
+    var componentLookup = container.lookup('component-lookup:main');
+    Ember.assert("Could not find 'component-lookup:main' on the provided container," +
+                 " which is necessary for performing component lookups", componentLookup);
+
+    if (container._registry.has('component:' + path) ||
+        container._registry.has('template:components/' + path)) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/packages/ember-htmlbars/lib/hooks/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/invoke-helper.js
@@ -15,32 +15,49 @@ HelperStream.prototype = create(Stream.prototype);
 
 merge(HelperStream.prototype, {
   compute() {
+    // FIXME: when a factory is present, use create
     return this.helper.compute(this.params, this.hash);
-  }
+  },
+  destroy() {
+    if (this.super$destroy(...arguments)) {
+      if (this.helper.destroy) {
+        this.helper.destroy();
+      }
+    }
+  },
+  super$destroy: Stream.prototype.destroy
 });
 
 export default function invokeHelper(morph, env, scope, visitor, _params, _hash, helper, templates, context) {
   var params, hash;
 
+  // Ember.Helper.build, Ember.Helper.extend, Ember.HTMLBars.makeBoundHelper
   if (helper.isHelper) {
     Ember.assert("Helpers may not be used in the block form, for example {{#my-helper}}{{/my-helper}}. Please use a component, or alternatively use the helper in combination with a built-in Ember helper, for example {{#if (my-helper)}}{{/if}}.", !templates.template.meta);
     params = getArrayValues(_params);
     hash = getHashValues(_hash);
     var helperStream = new HelperStream(helper, params, hash);
     helper._stream = helperStream;
-    helperStream.subscribe(function() {
-      morph.setContent(helperStream.value());
-    });
+    // FIXME this is obviously insane.
+    if (morph) {
+      helperStream.subscribe(function() {
+        morph.setContent(helperStream.value());
+      });
+      morph.addDestruction(helperStream);
+    }
     return { value: helperStream.value() };
+  // Ember.Handlebars.makeBoundHelper
   } else if (helper.helperFunction) {
     var helperFunc = helper.helperFunction;
     return { value: helperFunc.call({}, _params, _hash, templates, env, scope) };
+  // Ember.Handlebars.makeViewHelper or Ember.HTMLBars?
   } else if (helper.isLegacyViewHelper) {
     Ember.assert("You can only pass attributes (such as name=value) not bare " +
                  "values to a helper for a View found in '" + helper.viewClass + "'", _params.length === 0);
 
     env.hooks.keyword('view', morph, env, scope, [helper.viewClass], _hash, templates.template.raw, null, visitor);
     return { handled: true };
+  // built-in helpers
   } else if (typeof helper === 'function') {
     params = getArrayValues(_params);
     hash = getHashValues(_hash);

--- a/packages/ember-htmlbars/lib/hooks/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/invoke-helper.js
@@ -1,86 +1,26 @@
 import Ember from 'ember-metal/core'; // Ember.assert
-import merge from "ember-metal/merge";
-import getValue from "ember-htmlbars/hooks/get-value";
-import Stream from "ember-metal/streams/stream";
-import create from "ember-metal/platform/create";
+import { buildHelperStream } from "ember-htmlbars/system/invoke-helper";
 
-function HelperStream(helper, params, hash, label) {
-  this.init(label);
-  this.helper = helper;
-  this.params = params;
-  this.hash = hash;
-}
+export default function invokeHelper(morph, env, scope, visitor, params, hash, helper, templates, context) {
 
-HelperStream.prototype = create(Stream.prototype);
-
-merge(HelperStream.prototype, {
-  compute() {
-    // FIXME: when a factory is present, use create
-    return this.helper.compute(this.params, this.hash);
-  },
-  destroy() {
-    if (this.super$destroy(...arguments)) {
-      if (this.helper.destroy) {
-        this.helper.destroy();
-      }
-    }
-  },
-  super$destroy: Stream.prototype.destroy
-});
-
-export default function invokeHelper(morph, env, scope, visitor, _params, _hash, helper, templates, context) {
-  var params, hash;
-
-  // Ember.Helper.build, Ember.Helper.extend, Ember.HTMLBars.makeBoundHelper
-  if (helper.isHelper) {
-    Ember.assert("Helpers may not be used in the block form, for example {{#my-helper}}{{/my-helper}}. Please use a component, or alternatively use the helper in combination with a built-in Ember helper, for example {{#if (my-helper)}}{{/if}}.", !templates.template.meta);
-    params = getArrayValues(_params);
-    hash = getHashValues(_hash);
-    var helperStream = new HelperStream(helper, params, hash);
-    helper._stream = helperStream;
-    // FIXME this is obviously insane.
-    if (morph) {
-      helperStream.subscribe(function() {
-        morph.setContent(helperStream.value());
-      });
-      morph.addDestruction(helperStream);
-    }
-    return { value: helperStream.value() };
-  // Ember.Handlebars.makeBoundHelper
-  } else if (helper.helperFunction) {
-    var helperFunc = helper.helperFunction;
-    return { value: helperFunc.call({}, _params, _hash, templates, env, scope) };
-  // Ember.Handlebars.makeViewHelper or Ember.HTMLBars?
-  } else if (helper.isLegacyViewHelper) {
+  if (helper.isLegacyViewHelper) {
     Ember.assert("You can only pass attributes (such as name=value) not bare " +
-                 "values to a helper for a View found in '" + helper.viewClass + "'", _params.length === 0);
+                 "values to a helper for a View found in '" + helper.viewClass + "'", params.length === 0);
 
-    env.hooks.keyword('view', morph, env, scope, [helper.viewClass], _hash, templates.template.raw, null, visitor);
+    env.hooks.keyword('view', morph, env, scope, [helper.viewClass], hash, templates.template.raw, null, visitor);
     return { handled: true };
-  // built-in helpers
-  } else if (typeof helper === 'function') {
-    params = getArrayValues(_params);
-    hash = getHashValues(_hash);
-    return { value: helper.call(context, params, hash, templates) };
-  }
-}
-
-// We don't want to leak mutable cells into helpers, which
-// are pure functions that can only work with values.
-function getArrayValues(params) {
-  let out = [];
-  for (let i=0, l=params.length; i<l; i++) {
-    out.push(getValue(params[i]));
   }
 
-  return out;
-}
-
-function getHashValues(hash) {
-  let out = {};
-  for (let prop in hash) {
-    out[prop] = getValue(hash[prop]);
+  var helperStream = buildHelperStream(helper, params, hash, templates, env, scope, context);
+  // FIXME this is obviously insane.
+  if (morph) {
+    helperStream.subscribe(function() {
+      morph.setContent(helperStream.value());
+    });
+    morph.addDestruction(helperStream);
+    return { value: helperStream.value() };
+  } else {
+    // FIXME when is this hit?
+    return helperStream;
   }
-
-  return out;
 }

--- a/packages/ember-htmlbars/lib/hooks/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/invoke-helper.js
@@ -13,19 +13,19 @@ export default function invokeHelper(morph, env, scope, visitor, _params, _hash,
       morph.setContent(helperStream.value());
     });
     return { value: helperStream.value() };
-  } else if (typeof helper === 'function') {
-    params = getArrayValues(_params);
-    hash = getHashValues(_hash);
-    return { value: helper.call(context, params, hash, templates) };
+  } else if (helper.helperFunction) {
+    var helperFunc = helper.helperFunction;
+    return { value: helperFunc.call({}, _params, _hash, templates, env, scope) };
   } else if (helper.isLegacyViewHelper) {
     Ember.assert("You can only pass attributes (such as name=value) not bare " +
                  "values to a helper for a View found in '" + helper.viewClass + "'", _params.length === 0);
 
     env.hooks.keyword('view', morph, env, scope, [helper.viewClass], _hash, templates.template.raw, null, visitor);
     return { handled: true };
-  } else if (helper && helper.helperFunction) {
-    var helperFunc = helper.helperFunction;
-    return { value: helperFunc.call({}, _params, _hash, templates, env, scope) };
+  } else if (typeof helper === 'function') {
+    params = getArrayValues(_params);
+    hash = getHashValues(_hash);
+    return { value: helper.call(context, params, hash, templates) };
   }
 }
 

--- a/packages/ember-htmlbars/lib/hooks/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/invoke-helper.js
@@ -5,9 +5,10 @@ export default function invokeHelper(morph, env, scope, visitor, _params, _hash,
   var params, hash;
 
   if (helper.isHelper) {
+    Ember.assert("makeBoundHelper generated helpers do not support use with blocks", !templates.template.meta);
     params = getArrayValues(_params);
     hash = getHashValues(_hash);
-    var helperStream = helper.getStream();
+    var helperStream = helper.getStream(params, hash);
     helperStream.subscribe(function() {
       morph.setContent(helperStream.value());
     });

--- a/packages/ember-htmlbars/lib/hooks/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/invoke-helper.js
@@ -12,15 +12,9 @@ export default function invokeHelper(morph, env, scope, visitor, params, hash, h
   }
 
   var helperStream = buildHelperStream(helper, params, hash, templates, env, scope, context);
-  // FIXME this is obviously insane.
-  if (morph) {
-    helperStream.subscribe(function() {
-      morph.setContent(helperStream.value());
-    });
-    morph.addDestruction(helperStream);
-    return { value: helperStream.value() };
-  } else {
-    // FIXME when is this hit?
-    return helperStream;
-  }
+  helperStream.subscribe(function() {
+    morph.setContent(helperStream.value());
+  });
+  morph.addDestruction(helperStream);
+  return { value: helperStream.value() };
 }

--- a/packages/ember-htmlbars/lib/hooks/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/invoke-helper.js
@@ -12,9 +12,6 @@ export default function invokeHelper(morph, env, scope, visitor, params, hash, h
   }
 
   var helperStream = buildHelperStream(helper, params, hash, templates, env, scope, context);
-  helperStream.subscribe(function() {
-    morph.setContent(helperStream.value());
-  });
   morph.addDestruction(helperStream);
-  return { value: helperStream.value() };
+  return { link: true, value: helperStream };
 }

--- a/packages/ember-htmlbars/lib/hooks/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/invoke-helper.js
@@ -5,7 +5,7 @@ export default function invokeHelper(morph, env, scope, visitor, _params, _hash,
   var params, hash;
 
   if (helper.isHelper) {
-    Ember.assert("makeBoundHelper generated helpers do not support use with blocks", !templates.template.meta);
+    Ember.assert("Helpers may not be used in the block form, for example {{#my-helper}}{{/my-helper}}. Please use a component, or alternatively use the helper in combination with a built-in Ember helper, for example {{#if (my-helper)}}{{/if}}.", !templates.template.meta);
     params = getArrayValues(_params);
     hash = getHashValues(_hash);
     var helperStream = helper.getStream(params, hash);

--- a/packages/ember-htmlbars/lib/hooks/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/hooks/invoke-helper.js
@@ -1,12 +1,18 @@
 import Ember from 'ember-metal/core'; // Ember.assert
 import getValue from "ember-htmlbars/hooks/get-value";
 
-
-
 export default function invokeHelper(morph, env, scope, visitor, _params, _hash, helper, templates, context) {
   var params, hash;
 
-  if (typeof helper === 'function') {
+  if (helper.isHelper) {
+    params = getArrayValues(_params);
+    hash = getHashValues(_hash);
+    var helperStream = helper.getStream();
+    helperStream.subscribe(function() {
+      morph.setContent(helperStream.value());
+    });
+    return { value: helperStream.value() };
+  } else if (typeof helper === 'function') {
     params = getArrayValues(_params);
     hash = getHashValues(_hash);
     return { value: helper.call(context, params, hash, templates) };

--- a/packages/ember-htmlbars/lib/main.js
+++ b/packages/ember-htmlbars/lib/main.js
@@ -31,6 +31,7 @@ import legacyEachWithKeywordHelper from "ember-htmlbars/helpers/-legacy-each-wit
 import getHelper from "ember-htmlbars/helpers/-get";
 import htmlSafeHelper from "ember-htmlbars/helpers/-html-safe";
 import DOMHelper from "ember-htmlbars/system/dom-helper";
+import Helper from "ember-htmlbars/helper";
 
 // importing adds template bootstrapping
 // initializer to enable embedded templates
@@ -70,3 +71,5 @@ Ember.HTMLBars = {
   registerPlugin: registerPlugin,
   DOMHelper
 };
+
+Ember.Helper = Helper;

--- a/packages/ember-htmlbars/lib/streams/built-in-helper.js
+++ b/packages/ember-htmlbars/lib/streams/built-in-helper.js
@@ -1,0 +1,27 @@
+import Stream from "ember-metal/streams/stream";
+import create from "ember-metal/platform/create";
+import merge from "ember-metal/merge";
+import {
+  getArrayValues,
+  getHashValues
+} from "ember-htmlbars/streams/utils";
+
+export default function BuiltInHelperStream(helper, params, hash, templates, env, scope, context, label) {
+  this.init(label);
+  this.helper = helper;
+  this.params = params;
+  this.templates = templates;
+  this.env = env;
+  this.scope = scope;
+  this.hash = hash;
+  this.context = context;
+}
+
+BuiltInHelperStream.prototype = create(Stream.prototype);
+
+merge(BuiltInHelperStream.prototype, {
+  compute() {
+    // Using call and undefined is probably not needed, these are only internal
+    return this.helper.call(this.context, getArrayValues(this.params), getHashValues(this.hash), this.templates, this.env, this.scope);
+  }
+});

--- a/packages/ember-htmlbars/lib/streams/compat-helper.js
+++ b/packages/ember-htmlbars/lib/streams/compat-helper.js
@@ -1,0 +1,22 @@
+import Stream from "ember-metal/streams/stream";
+import create from "ember-metal/platform/create";
+import merge from "ember-metal/merge";
+
+export default function CompatHelperStream(helper, params, hash, templates, env, scope, label) {
+  this.init(label);
+  this.helper = helper.helperFunction;
+  this.params = params;
+  this.templates = templates;
+  this.env = env;
+  this.scope = scope;
+  this.hash = hash;
+}
+
+CompatHelperStream.prototype = create(Stream.prototype);
+
+merge(CompatHelperStream.prototype, {
+  compute() {
+    // Using call and undefined is probably not needed, these are only internal
+    return this.helper.call(undefined, this.params, this.hash, this.templates, this.env, this.scope);
+  }
+});

--- a/packages/ember-htmlbars/lib/streams/helper-factory.js
+++ b/packages/ember-htmlbars/lib/streams/helper-factory.js
@@ -6,11 +6,12 @@ import {
   getHashValues
 } from "ember-htmlbars/streams/utils";
 
-export default function HelperFactoryStream(helperFactory, params, hash, label) {
+export default function HelperFactoryStream(helperFactory, params, hash, view, label) {
   this.init(label);
   this.helperFactory = helperFactory;
   this.params = params;
   this.hash = hash;
+  this.view = view;
 }
 
 HelperFactoryStream.prototype = create(Stream.prototype);
@@ -18,7 +19,7 @@ HelperFactoryStream.prototype = create(Stream.prototype);
 merge(HelperFactoryStream.prototype, {
   compute() {
     if (!this.helper) {
-      this.helper = this.helperFactory.create({ _stream: this });
+      this.helper = this.helperFactory.create({ _stream: this, _view: this.view });
     }
     return this.helper.compute(getArrayValues(this.params), getHashValues(this.hash));
   },

--- a/packages/ember-htmlbars/lib/streams/helper-factory.js
+++ b/packages/ember-htmlbars/lib/streams/helper-factory.js
@@ -20,7 +20,6 @@ merge(HelperFactoryStream.prototype, {
     if (!this.helper) {
       this.helper = this.helperFactory.create({ _stream: this });
     }
-    // FIXME: when a factory is present, use create
     return this.helper.compute(getArrayValues(this.params), getHashValues(this.hash));
   },
   destroy() {

--- a/packages/ember-htmlbars/lib/streams/helper-factory.js
+++ b/packages/ember-htmlbars/lib/streams/helper-factory.js
@@ -1,0 +1,34 @@
+import Stream from "ember-metal/streams/stream";
+import create from "ember-metal/platform/create";
+import merge from "ember-metal/merge";
+import {
+  getArrayValues,
+  getHashValues
+} from "ember-htmlbars/streams/utils";
+
+export default function HelperFactoryStream(helperFactory, params, hash, label) {
+  this.init(label);
+  this.helperFactory = helperFactory;
+  this.params = params;
+  this.hash = hash;
+}
+
+HelperFactoryStream.prototype = create(Stream.prototype);
+
+merge(HelperFactoryStream.prototype, {
+  compute() {
+    if (!this.helper) {
+      this.helper = this.helperFactory.create({ _stream: this });
+    }
+    // FIXME: when a factory is present, use create
+    return this.helper.compute(getArrayValues(this.params), getHashValues(this.hash));
+  },
+  destroy() {
+    if (this.super$destroy(...arguments)) {
+      if (this.helper.destroy) {
+        this.helper.destroy();
+      }
+    }
+  },
+  super$destroy: Stream.prototype.destroy
+});

--- a/packages/ember-htmlbars/lib/streams/helper-instance.js
+++ b/packages/ember-htmlbars/lib/streams/helper-instance.js
@@ -1,0 +1,22 @@
+import Stream from "ember-metal/streams/stream";
+import create from "ember-metal/platform/create";
+import merge from "ember-metal/merge";
+import {
+  getArrayValues,
+  getHashValues
+} from "ember-htmlbars/streams/utils";
+
+export default function HelperInstanceStream(helper, params, hash, label) {
+  this.init(label);
+  this.helper = helper;
+  this.params = params;
+  this.hash = hash;
+}
+
+HelperInstanceStream.prototype = create(Stream.prototype);
+
+merge(HelperInstanceStream.prototype, {
+  compute() {
+    return this.helper.compute(getArrayValues(this.params), getHashValues(this.hash));
+  }
+});

--- a/packages/ember-htmlbars/lib/streams/utils.js
+++ b/packages/ember-htmlbars/lib/streams/utils.js
@@ -1,0 +1,21 @@
+import getValue from "ember-htmlbars/hooks/get-value";
+
+// We don't want to leak mutable cells into helpers, which
+// are pure functions that can only work with values.
+export function getArrayValues(params) {
+  let out = [];
+  for (let i=0, l=params.length; i<l; i++) {
+    out.push(getValue(params[i]));
+  }
+
+  return out;
+}
+
+export function getHashValues(hash) {
+  let out = {};
+  for (let prop in hash) {
+    out[prop] = getValue(hash[prop]);
+  }
+
+  return out;
+}

--- a/packages/ember-htmlbars/lib/system/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/system/invoke-helper.js
@@ -1,0 +1,17 @@
+import HelperInstanceStream from "ember-htmlbars/streams/helper-instance";
+import HelperFactoryStream from "ember-htmlbars/streams/helper-factory";
+import BuiltInHelperStream from "ember-htmlbars/streams/built-in-helper";
+import CompatHelperStream from "ember-htmlbars/streams/compat-helper";
+
+export function buildHelperStream(helper, params, hash, templates, env, scope, context, label) {
+  Ember.assert("Helpers may not be used in the block form, for example {{#my-helper}}{{/my-helper}}. Please use a component, or alternatively use the helper in combination with a built-in Ember helper, for example {{#if (my-helper)}}{{/if}}.", !helper.isHelperInstance || !helper.isHelperFactory && !templates.template.meta);
+  if (helper.isHelperFactory) {
+    return new HelperFactoryStream(helper, params, hash, label);
+  } else if (helper.isHelperInstance) {
+    return new HelperInstanceStream(helper, params, hash, label);
+  } else if (helper.helperFunction) {
+    return new CompatHelperStream(helper, params, hash, templates, env, scope, label);
+  } else {
+    return new BuiltInHelperStream(helper, params, hash, templates, env, scope, context, label);
+  }
+}

--- a/packages/ember-htmlbars/lib/system/invoke-helper.js
+++ b/packages/ember-htmlbars/lib/system/invoke-helper.js
@@ -6,7 +6,7 @@ import CompatHelperStream from "ember-htmlbars/streams/compat-helper";
 export function buildHelperStream(helper, params, hash, templates, env, scope, context, label) {
   Ember.assert("Helpers may not be used in the block form, for example {{#my-helper}}{{/my-helper}}. Please use a component, or alternatively use the helper in combination with a built-in Ember helper, for example {{#if (my-helper)}}{{/if}}.", !helper.isHelperInstance || !helper.isHelperFactory && !templates.template.meta);
   if (helper.isHelperFactory) {
-    return new HelperFactoryStream(helper, params, hash, label);
+    return new HelperFactoryStream(helper, params, hash, env.view, label);
   } else if (helper.isHelperInstance) {
     return new HelperInstanceStream(helper, params, hash, label);
   } else if (helper.helperFunction) {

--- a/packages/ember-htmlbars/lib/system/lookup-helper.js
+++ b/packages/ember-htmlbars/lib/system/lookup-helper.js
@@ -5,8 +5,6 @@
 
 import Ember from "ember-metal/core";
 import Cache from "ember-metal/cache";
-import makeViewHelper from "ember-htmlbars/system/make-view-helper";
-import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 
 export var CONTAINS_DASH_CACHE = new Cache(1000, function(key) {
   return key.indexOf('-') !== -1;
@@ -14,7 +12,7 @@ export var CONTAINS_DASH_CACHE = new Cache(1000, function(key) {
 
 export function validateLazyHelperName(helperName, container, keywords) {
   return container && CONTAINS_DASH_CACHE.get(helperName) && !(helperName in keywords);
-};
+}
 
 /**
   Used to lookup/resolve handlebars helpers. The lookup order is:

--- a/packages/ember-htmlbars/lib/system/lookup-helper.js
+++ b/packages/ember-htmlbars/lib/system/lookup-helper.js
@@ -41,27 +41,16 @@ export function findHelper(name, view, env) {
   if (validateLazyHelperName(name, container, env.hooks.keywords)) {
     var helperName = 'helper:' + name;
 
-    helper = container.lookup(helperName);
-
-    if (helper && !helper.isHTMLBars && !helper.isHelper) {
-      helper = new HandlebarsCompatibleHelper(helper);
-      container._registry.unregister(helperName);
-      container._registry.register(helperName, helper);
-    }
-
-    if (!helper) {
-      var componentLookup = container.lookup('component-lookup:main');
-      Ember.assert("Could not find 'component-lookup:main' on the provided container," +
-                   " which is necessary for performing component lookups", componentLookup);
-
-      var Component = componentLookup.lookupFactory(name, container);
-      if (Component) {
-        helper = makeViewHelper(Component);
+    if (container._registry.has(helperName)) {
+      helper = container.lookup(helperName);
+      if (helper && !helper.isHTMLBars && !helper.isHelper) {
+        helper = new HandlebarsCompatibleHelper(helper);
+        container._registry.unregister(helperName);
         container._registry.register(helperName, helper);
       }
+      return helper;
     }
 
-    return helper;
   }
 }
 

--- a/packages/ember-htmlbars/lib/system/lookup-helper.js
+++ b/packages/ember-htmlbars/lib/system/lookup-helper.js
@@ -38,8 +38,8 @@ export function findHelper(name, view, env) {
       var helperName = 'helper:' + name;
       if (container._registry.has(helperName)) {
         var _helper;
-        Ember.assert(`The factory for "${name}" is not an Ember helper. Please use Ember.Helper.build to wrap helper functions.`, (_helper = container._registry.resolve(helperName)) && _helper && _helper.isHelperFactory);
-        helper = container.lookup(helperName);
+        Ember.assert(`The factory for "${name}" is not an Ember helper. Please use Ember.Helper.build to wrap helper functions.`, (_helper = container._registry.resolve(helperName)) && _helper && (_helper.isHelperFactory || _helper.isHelperInstance || _helper.isHTMLBars));
+        helper = container.lookupFactory(helperName);
       }
     }
   }

--- a/packages/ember-htmlbars/lib/system/lookup-helper.js
+++ b/packages/ember-htmlbars/lib/system/lookup-helper.js
@@ -8,9 +8,13 @@ import Cache from "ember-metal/cache";
 import makeViewHelper from "ember-htmlbars/system/make-view-helper";
 import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 
-export var ISNT_HELPER_CACHE = new Cache(1000, function(key) {
-  return key.indexOf('-') === -1;
+export var CONTAINS_DASH_CACHE = new Cache(1000, function(key) {
+  return key.indexOf('-') !== -1;
 });
+
+export function validateLazyHelperName(helperName, container, keywords) {
+  return container && CONTAINS_DASH_CACHE.get(helperName) && !(helperName in keywords);
+};
 
 /**
   Used to lookup/resolve handlebars helpers. The lookup order is:
@@ -34,37 +38,31 @@ export function findHelper(name, view, env) {
   }
 
   var container = env.container;
+  if (validateLazyHelperName(name, container, env.hooks.keywords)) {
+    var helperName = 'helper:' + name;
 
-  if (!container || ISNT_HELPER_CACHE.get(name)) {
-    return;
-  }
+    helper = container.lookup(helperName);
 
-  if (name in env.hooks.keywords) {
-    return;
-  }
-
-  var helperName = 'helper:' + name;
-  console.log(helperName);
-  helper = container.lookup(helperName);
-  if (!helper) {
-    var componentLookup = container.lookup('component-lookup:main');
-    Ember.assert("Could not find 'component-lookup:main' on the provided container," +
-                 " which is necessary for performing component lookups", componentLookup);
-
-    var Component = componentLookup.lookupFactory(name, container);
-    if (Component) {
-      helper = makeViewHelper(Component);
+    if (helper && !helper.isHTMLBars && !helper.isHelper) {
+      helper = new HandlebarsCompatibleHelper(helper);
+      container._registry.unregister(helperName);
       container._registry.register(helperName, helper);
     }
-  }
 
-  if (helper && !helper.isHTMLBars && !helper.isHelper) {
-    helper = new HandlebarsCompatibleHelper(helper);
-    container._registry.unregister(helperName);
-    container._registry.register(helperName, helper);
-  }
+    if (!helper) {
+      var componentLookup = container.lookup('component-lookup:main');
+      Ember.assert("Could not find 'component-lookup:main' on the provided container," +
+                   " which is necessary for performing component lookups", componentLookup);
 
-  return helper;
+      var Component = componentLookup.lookupFactory(name, container);
+      if (Component) {
+        helper = makeViewHelper(Component);
+        container._registry.register(helperName, helper);
+      }
+    }
+
+    return helper;
+  }
 }
 
 export default function lookupHelper(name, view, env) {

--- a/packages/ember-htmlbars/lib/system/lookup-helper.js
+++ b/packages/ember-htmlbars/lib/system/lookup-helper.js
@@ -33,25 +33,20 @@ export function validateLazyHelperName(helperName, container, keywords) {
 */
 export function findHelper(name, view, env) {
   var helper = env.helpers[name];
-  if (helper) {
-    return helper;
-  }
 
-  var container = env.container;
-  if (validateLazyHelperName(name, container, env.hooks.keywords)) {
-    var helperName = 'helper:' + name;
-
-    if (container._registry.has(helperName)) {
-      helper = container.lookup(helperName);
-      if (helper && !helper.isHTMLBars && !helper.isHelper) {
-        helper = new HandlebarsCompatibleHelper(helper);
-        container._registry.unregister(helperName);
-        container._registry.register(helperName, helper);
+  if (!helper) {
+    var container = env.container;
+    if (validateLazyHelperName(name, container, env.hooks.keywords)) {
+      var helperName = 'helper:' + name;
+      if (container._registry.has(helperName)) {
+        var _helper;
+        Ember.assert(`The factory for "${name}" is not an Ember helper. Please use Ember.Helper.build to wrap helper functions.`, (_helper = container._registry.resolve(helperName)) && _helper && _helper.isHelperFactory);
+        helper = container.lookup(helperName);
       }
-      return helper;
     }
-
   }
+
+  return helper;
 }
 
 export default function lookupHelper(name, view, env) {

--- a/packages/ember-htmlbars/lib/system/lookup-helper.js
+++ b/packages/ember-htmlbars/lib/system/lookup-helper.js
@@ -44,6 +44,7 @@ export function findHelper(name, view, env) {
   }
 
   var helperName = 'helper:' + name;
+  console.log(helperName);
   helper = container.lookup(helperName);
   if (!helper) {
     var componentLookup = container.lookup('component-lookup:main');
@@ -57,7 +58,7 @@ export function findHelper(name, view, env) {
     }
   }
 
-  if (helper && !helper.isHTMLBars) {
+  if (helper && !helper.isHTMLBars && !helper.isHelper) {
     helper = new HandlebarsCompatibleHelper(helper);
     container._registry.unregister(helperName);
     container._registry.register(helperName, helper);

--- a/packages/ember-htmlbars/lib/system/make-view-helper.js
+++ b/packages/ember-htmlbars/lib/system/make-view-helper.js
@@ -18,7 +18,6 @@ export default function makeViewHelper(ViewClass) {
   return {
     isLegacyViewHelper: true,
     isHTMLBars: true,
-    viewClass: ViewClass,
-    reopenClass() {}
+    viewClass: ViewClass
   };
 }

--- a/packages/ember-htmlbars/lib/system/make-view-helper.js
+++ b/packages/ember-htmlbars/lib/system/make-view-helper.js
@@ -19,8 +19,6 @@ export default function makeViewHelper(ViewClass) {
     isLegacyViewHelper: true,
     isHTMLBars: true,
     viewClass: ViewClass,
-    isHelperFactory: true,
-    create() { return this; },
     reopenClass() {}
   };
 }

--- a/packages/ember-htmlbars/lib/system/make-view-helper.js
+++ b/packages/ember-htmlbars/lib/system/make-view-helper.js
@@ -18,6 +18,9 @@ export default function makeViewHelper(ViewClass) {
   return {
     isLegacyViewHelper: true,
     isHTMLBars: true,
-    viewClass: ViewClass
+    viewClass: ViewClass,
+    create() { return this },
+    extend() { return this },
+    reopenClass() {}
   };
 }

--- a/packages/ember-htmlbars/lib/system/make-view-helper.js
+++ b/packages/ember-htmlbars/lib/system/make-view-helper.js
@@ -20,7 +20,7 @@ export default function makeViewHelper(ViewClass) {
     isHTMLBars: true,
     viewClass: ViewClass,
     isHelperFactory: true,
-    create() { return this },
+    create() { return this; },
     reopenClass() {}
   };
 }

--- a/packages/ember-htmlbars/lib/system/make-view-helper.js
+++ b/packages/ember-htmlbars/lib/system/make-view-helper.js
@@ -19,8 +19,8 @@ export default function makeViewHelper(ViewClass) {
     isLegacyViewHelper: true,
     isHTMLBars: true,
     viewClass: ViewClass,
+    isHelperFactory: true,
     create() { return this },
-    extend() { return this },
     reopenClass() {}
   };
 }

--- a/packages/ember-htmlbars/lib/system/make_bound_helper.js
+++ b/packages/ember-htmlbars/lib/system/make_bound_helper.js
@@ -4,7 +4,6 @@
 */
 
 import Helper from "ember-htmlbars/helper";
-import { readHash, readArray } from "ember-metal/streams/utils";
 
 /**
   Create a bound helper. Accepts a function that receives the ordered and hash parameters

--- a/packages/ember-htmlbars/lib/system/make_bound_helper.js
+++ b/packages/ember-htmlbars/lib/system/make_bound_helper.js
@@ -3,7 +3,7 @@
 @submodule ember-htmlbars
 */
 
-import Helper from "ember-htmlbars/system/helper";
+import Helper from "ember-htmlbars/helper";
 import { readHash, readArray } from "ember-metal/streams/utils";
 
 /**
@@ -50,8 +50,5 @@ import { readHash, readArray } from "ember-metal/streams/utils";
   @since 1.10.0
 */
 export default function makeBoundHelper(fn) {
-  return new Helper(function(params, hash, templates) {
-    Ember.assert("makeBoundHelper generated helpers do not support use with blocks", !templates.template.meta);
-    return fn(readArray(params), readHash(hash));
-  });
+  return Helper.build(fn);
 }

--- a/packages/ember-htmlbars/lib/utils/is-component.js
+++ b/packages/ember-htmlbars/lib/utils/is-component.js
@@ -3,7 +3,7 @@
 @submodule ember-htmlbars
 */
 
-import { ISNT_HELPER_CACHE } from "ember-htmlbars/system/lookup-helper";
+import { CONTAINS_DASH_CACHE } from "ember-htmlbars/system/lookup-helper";
 
 /*
  Given a path name, returns whether or not a component with that
@@ -12,7 +12,7 @@ import { ISNT_HELPER_CACHE } from "ember-htmlbars/system/lookup-helper";
 export default function isComponent(env, scope, path) {
   var container = env.container;
   if (!container) { return false; }
-  if (ISNT_HELPER_CACHE.get(path)) { return false; }
+  if (!CONTAINS_DASH_CACHE.get(path)) { return false; }
   return container._registry.has('component:' + path) ||
          container._registry.has('template:components/' + path);
 }

--- a/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
+++ b/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
@@ -18,7 +18,6 @@ QUnit.module("ember-htmlbars: compat - Ember.Handlebars.get", {
     registry = new Registry();
     container = registry.container();
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { singleton: false });
     registry.register('view:toplevel', EmberView.extend());
   },
 

--- a/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
+++ b/packages/ember-htmlbars/tests/compat/handlebars_get_test.js
@@ -3,6 +3,7 @@ import EmberView from "ember-views/views/view";
 import handlebarsGet from "ember-htmlbars/compat/handlebars-get";
 import { Registry } from "ember-runtime/system/container";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 
 import EmberHandlebars from "ember-htmlbars/compat";
 
@@ -17,7 +18,7 @@ QUnit.module("ember-htmlbars: compat - Ember.Handlebars.get", {
     registry = new Registry();
     container = registry.container();
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
     registry.register('view:toplevel', EmberView.extend());
   },
 
@@ -34,13 +35,13 @@ QUnit.module("ember-htmlbars: compat - Ember.Handlebars.get", {
 QUnit.test('it can lookup a path from the current context', function() {
   expect(1);
 
-  registry.register('helper:handlebars-get', function(path, options) {
+  registry.register('helper:handlebars-get', new HandlebarsCompatibleHelper(function(path, options) {
     var context = options.contexts && options.contexts[0] || this;
 
     ignoreDeprecation(function() {
       equal(handlebarsGet(context, path, options), 'bar');
     });
-  });
+  }));
 
   view = EmberView.create({
     container: container,
@@ -56,13 +57,13 @@ QUnit.test('it can lookup a path from the current context', function() {
 QUnit.test('it can lookup a path from the current keywords', function() {
   expect(1);
 
-  registry.register('helper:handlebars-get', function(path, options) {
+  registry.register('helper:handlebars-get', new HandlebarsCompatibleHelper(function(path, options) {
     var context = options.contexts && options.contexts[0] || this;
 
     ignoreDeprecation(function() {
       equal(handlebarsGet(context, path, options), 'bar');
     });
-  });
+  }));
 
   view = EmberView.create({
     container: container,
@@ -80,13 +81,13 @@ QUnit.test('it can lookup a path from globals', function() {
 
   lookup.Blammo = { foo: 'blah' };
 
-  registry.register('helper:handlebars-get', function(path, options) {
+  registry.register('helper:handlebars-get', new HandlebarsCompatibleHelper(function(path, options) {
     var context = options.contexts && options.contexts[0] || this;
 
     ignoreDeprecation(function() {
       equal(handlebarsGet(context, path, options), lookup.Blammo.foo);
     });
-  });
+  }));
 
   view = EmberView.create({
     container: container,
@@ -100,13 +101,13 @@ QUnit.test('it can lookup a path from globals', function() {
 QUnit.test('it raises a deprecation warning on use', function() {
   expect(1);
 
-  registry.register('helper:handlebars-get', function(path, options) {
+  registry.register('helper:handlebars-get', new HandlebarsCompatibleHelper(function(path, options) {
     var context = options.contexts && options.contexts[0] || this;
 
     expectDeprecation(function() {
       handlebarsGet(context, path, options);
     }, 'Usage of Ember.Handlebars.get is deprecated, use a Component or Ember.Handlebars.makeBoundHelper instead.');
-  });
+  }));
 
   view = EmberView.create({
     container: container,

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -22,7 +22,6 @@ QUnit.module('ember-htmlbars: compat - Handlebars compatible helpers', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { singleton: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
   teardown() {

--- a/packages/ember-htmlbars/tests/compat/helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/helper_test.js
@@ -11,6 +11,7 @@ import compile from "ember-template-compiler/system/compile";
 import { runAppend, runDestroy } from "ember-runtime/tests/utils";
 import Registry from "container/registry";
 import ComponentLookup from 'ember-views/component_lookup';
+import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 
 var view, registry, container;
 
@@ -21,7 +22,7 @@ QUnit.module('ember-htmlbars: compat - Handlebars compatible helpers', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
   teardown() {
@@ -102,9 +103,9 @@ QUnit.test('has the correct options.data.view within a components layout', funct
   }));
 
   registry.register('template:components/foo-bar', compile('{{my-thing}}'));
-  registry.register('helper:my-thing', function(options) {
+  registry.register('helper:my-thing', new HandlebarsCompatibleHelper(function(options) {
     equal(options.data.view, component, 'passed in view should match the current component');
-  });
+  }));
 
   view = EmberView.create({
     container,

--- a/packages/ember-htmlbars/tests/compat/make-view-helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make-view-helper_test.js
@@ -11,7 +11,6 @@ QUnit.module('ember-htmlbars: compat - makeViewHelper compat', {
   setup() {
     registry = new Registry();
     container = registry.container();
-    registry.optionsForType('helper', { singleton: false });
   },
 
   teardown() {

--- a/packages/ember-htmlbars/tests/compat/make-view-helper_test.js
+++ b/packages/ember-htmlbars/tests/compat/make-view-helper_test.js
@@ -11,7 +11,7 @@ QUnit.module('ember-htmlbars: compat - makeViewHelper compat', {
   setup() {
     registry = new Registry();
     container = registry.container();
-    registry.optionsForType('helper', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
   },
 
   teardown() {

--- a/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
+++ b/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
@@ -274,3 +274,36 @@ QUnit.test('dashed helper used in subexpression can recompute', function() {
   equal(component.$().text(),
     'Who believes his force hath overcome but half his foe');
 });
+
+QUnit.test('dashed helper used in subexpression is destroyed', function() {
+  var didCallDestroy = false;
+  var DynamicSegment = Helper.extend({
+    phrase: 'overcomes by',
+    compute() {
+      return this.phrase;
+    },
+    destroy() {
+      didCallDestroy = true;
+      this._super(...arguments);
+    }
+  });
+  var JoinWords = Helper.build(function(params) {
+    return params.join(' ');
+  });
+  registry.register('helper:dynamic-segment', DynamicSegment);
+  registry.register('helper:join-words', JoinWords);
+  component = Component.extend({
+    container,
+    layout: compile(
+      `{{join-words "Who"
+                   (dynamic-segment)
+                   "force"
+                   (join-words (join-words "hath overcome but" "half"))
+                   (join-words "his" (join-words "foe"))}}`)
+  }).create();
+
+  runAppend(component);
+  runDestroy(component);
+
+  ok(didCallDestroy, 'destroy was called');
+});

--- a/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
+++ b/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
@@ -172,3 +172,28 @@ QUnit.test('dashed helper receives params, hash', function() {
   equal(params[1], 'rich', 'second argument is rich');
   equal(hash.last, 'sam', 'hash.last argument is sam');
 });
+
+QUnit.test('dashed helper usable in subexpressions', function() {
+  var params, hash;
+  var JoinWords = Helper.extend({
+    compute(params) {
+      return params.join(' ');
+    }
+  });
+  registry.register('helper:join-words', JoinWords);
+  component = Component.extend({
+    container,
+    name: 'bob',
+    layout: compile(
+      `{{join-words "Who"
+                   (join-words "overcomes" "by")
+                   "force"
+                   (join-words (join-words "hath overcome but" "half"))
+                   (join-words "his" (join-words "foe"))}}`)
+  }).create();
+
+  runAppend(component);
+
+  equal(component.$().text(),
+    'Who overcomes by force hath overcome but half his foe');
+});

--- a/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
+++ b/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
@@ -1,0 +1,84 @@
+import Component from "ember-views/views/component";
+import Helper from "ember-htmlbars/helper";
+import compile from "ember-template-compiler/system/compile";
+import { runAppend, runDestroy } from "ember-runtime/tests/utils";
+import Registry from "container/registry";
+import run from "ember-metal/run_loop";
+
+let registry, container, component;
+
+QUnit.module('ember-htmlbars: custom app helpers', {
+  setup() {
+    registry = new Registry();
+    registry.optionsForType('template', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
+    container = registry.container();
+  },
+
+  teardown() {
+    runDestroy(component);
+    runDestroy(container);
+    registry = container = component = null;
+  }
+});
+
+QUnit.test('dashed shorthand helper is resolved from container', function() {
+  var HelloWorld = Helper.build(function() {
+    return 'hello world';
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    layout: compile('{{hello-world}}')
+  }).create();
+
+  runAppend(component);
+  equal(component.$().text(), 'hello world');
+});
+
+QUnit.test('dashed helper is resolved from container', function() {
+  var HelloWorld = Helper.extend({
+    compute() {
+      return 'hello world';
+    }
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    layout: compile('{{hello-world}}')
+  }).create();
+
+  runAppend(component);
+  equal(component.$().text(), 'hello world');
+});
+
+QUnit.test('dashed helper can recompute a new value', function() {
+  var count = 0;
+  var helper;
+  // var didCreateHelper = false;
+  var HelloWorld = Helper.extend({
+    init() {
+      this._super(...arguments);
+      // This is run once for isHelper hook, but then not used. Should
+      // be FIXME.
+      // ok(!didCreateHelper, 'helper was created once');
+      // didCreateHelper = true;
+      helper = this;
+    },
+    compute() {
+      return ++count;
+    }
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    layout: compile('{{hello-world}}')
+  }).create();
+
+  runAppend(component);
+  equal(component.$().text(), '1');
+  run(function() {
+    helper.recompute();
+  });
+  equal(component.$().text(), '2');
+});

--- a/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
+++ b/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
@@ -59,8 +59,8 @@ QUnit.test('dashed helper can recompute a new value', function() {
   var HelloWorld = Helper.extend({
     init() {
       this._super(...arguments);
-       ok(!didCreateHelper, 'helper was created once');
-       didCreateHelper = true;
+      ok(!didCreateHelper, 'helper was created once');
+      didCreateHelper = true;
       helper = this;
     },
     compute() {
@@ -79,4 +79,96 @@ QUnit.test('dashed helper can recompute a new value', function() {
     helper.recompute();
   });
   equal(component.$().text(), '2');
+});
+
+QUnit.test('dashed shorthand helper is called for param changes', function() {
+  var count = 0;
+  var HelloWorld = Helper.build(function() {
+    return ++count;
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    name: 'bob',
+    layout: compile('{{hello-world name}}')
+  }).create();
+
+  runAppend(component);
+  equal(component.$().text(), '1');
+  run(function() {
+    component.set('name', 'sal');
+  });
+  equal(component.$().text(), '2');
+});
+
+QUnit.test('dashed helper compute is called for param changes', function() {
+  var count = 0;
+  // var didCreateHelper = false;
+  var HelloWorld = Helper.extend({
+    init() {
+      this._super(...arguments);
+      // FIXME: Ideally, the helper instance does not need to be recreated
+      // for change of params.
+      // ok(!didCreateHelper, 'helper was created once');
+      // didCreateHelper = true;
+    },
+    compute() {
+      return ++count;
+    }
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    name: 'bob',
+    layout: compile('{{hello-world name}}')
+  }).create();
+
+  runAppend(component);
+  equal(component.$().text(), '1');
+  run(function() {
+    component.set('name', 'sal');
+  });
+  equal(component.$().text(), '2');
+});
+
+QUnit.test('dashed shorthand helper receives params, hash', function() {
+  var params, hash;
+  var HelloWorld = Helper.build(function(_params, _hash) {
+    params = _params;
+    hash = _hash;
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    name: 'bob',
+    layout: compile('{{hello-world name "rich" last="sam"}}')
+  }).create();
+
+  runAppend(component);
+
+  equal(params[0], 'bob', 'first argument is bob');
+  equal(params[1], 'rich', 'second argument is rich');
+  equal(hash.last, 'sam', 'hash.last argument is sam');
+});
+
+QUnit.test('dashed helper receives params, hash', function() {
+  var params, hash;
+  var HelloWorld = Helper.extend({
+    compute(_params, _hash) {
+      params = _params;
+      hash = _hash;
+    }
+  });
+  registry.register('helper:hello-world', HelloWorld);
+  component = Component.extend({
+    container,
+    name: 'bob',
+    layout: compile('{{hello-world name "rich" last="sam"}}')
+  }).create();
+
+  runAppend(component);
+
+  equal(params[0], 'bob', 'first argument is bob');
+  equal(params[1], 'rich', 'second argument is rich');
+  equal(hash.last, 'sam', 'hash.last argument is sam');
 });

--- a/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
+++ b/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
@@ -208,3 +208,26 @@ QUnit.test('dashed helper not usable with a block', function() {
     runAppend(component);
   }, /Helpers may not be used in the block form/);
 });
+
+QUnit.test('dashed helper is torn down', function() {
+  var destroyCalled = 0;
+  var SomeHelper = Helper.extend({
+    destroy() {
+      destroyCalled++;
+      this._super.apply(this, arguments);
+    },
+    compute() {
+      return 'must define a compute';
+    }
+  });
+  registry.register('helper:some-helper', SomeHelper);
+  component = Component.extend({
+    container,
+    layout: compile(`{{some-helper}}`)
+  }).create();
+
+  runAppend(component);
+  runDestroy(component);
+
+  equal(destroyCalled, 1, 'destroy called once');
+});

--- a/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
+++ b/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
@@ -55,14 +55,12 @@ QUnit.test('dashed helper is resolved from container', function() {
 QUnit.test('dashed helper can recompute a new value', function() {
   var count = 0;
   var helper;
-  // var didCreateHelper = false;
+  var didCreateHelper = false;
   var HelloWorld = Helper.extend({
     init() {
       this._super(...arguments);
-      // This is run once for isHelper hook, but then not used. Should
-      // be FIXME.
-      // ok(!didCreateHelper, 'helper was created once');
-      // didCreateHelper = true;
+       ok(!didCreateHelper, 'helper was created once');
+       didCreateHelper = true;
       helper = this;
     },
     compute() {

--- a/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
+++ b/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
@@ -183,7 +183,6 @@ QUnit.test('dashed helper usable in subexpressions', function() {
   registry.register('helper:join-words', JoinWords);
   component = Component.extend({
     container,
-    name: 'bob',
     layout: compile(
       `{{join-words "Who"
                    (join-words "overcomes" "by")
@@ -196,4 +195,18 @@ QUnit.test('dashed helper usable in subexpressions', function() {
 
   equal(component.$().text(),
     'Who overcomes by force hath overcome but half his foe');
+});
+
+QUnit.test('dashed helper not usable with a block', function() {
+  var params, hash;
+  var SomeHelper = Helper.build(function(){});
+  registry.register('helper:some-helper', SomeHelper);
+  component = Component.extend({
+    container,
+    layout: compile(`{{#some-helper}}{{/some-helper}}`)
+  }).create();
+
+  expectAssertion(function() {
+    runAppend(component);
+  }, /Helpers may not be used in the block form/);
 });

--- a/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
+++ b/packages/ember-htmlbars/tests/helpers/custom_helper_test.js
@@ -174,7 +174,6 @@ QUnit.test('dashed helper receives params, hash', function() {
 });
 
 QUnit.test('dashed helper usable in subexpressions', function() {
-  var params, hash;
   var JoinWords = Helper.extend({
     compute(params) {
       return params.join(' ');
@@ -198,8 +197,7 @@ QUnit.test('dashed helper usable in subexpressions', function() {
 });
 
 QUnit.test('dashed helper not usable with a block', function() {
-  var params, hash;
-  var SomeHelper = Helper.build(function(){});
+  var SomeHelper = Helper.build(function() {});
   registry.register('helper:some-helper', SomeHelper);
   component = Component.extend({
     container,

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -482,7 +482,7 @@ QUnit.module("ember-htmlbars: {{#unbound}} helper -- Container Lookup", {
     Ember.lookup = lookup = { Ember: Ember };
     registry = new Registry();
     container = registry.container();
-    registry.optionsForType('helper', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
   },
 
   teardown() {

--- a/packages/ember-htmlbars/tests/helpers/unbound_test.js
+++ b/packages/ember-htmlbars/tests/helpers/unbound_test.js
@@ -482,7 +482,6 @@ QUnit.module("ember-htmlbars: {{#unbound}} helper -- Container Lookup", {
     Ember.lookup = lookup = { Ember: Ember };
     registry = new Registry();
     container = registry.container();
-    registry.optionsForType('helper', { singleton: false });
   },
 
   teardown() {

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -49,7 +49,7 @@ QUnit.module("ember-htmlbars: {{#view}} helper", {
     registry = new Registry();
     container = registry.container();
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
     registry.register('view:toplevel', EmberView.extend());
     registry.register('component-lookup:main', ComponentLookup);
   },

--- a/packages/ember-htmlbars/tests/helpers/view_test.js
+++ b/packages/ember-htmlbars/tests/helpers/view_test.js
@@ -49,7 +49,6 @@ QUnit.module("ember-htmlbars: {{#view}} helper", {
     registry = new Registry();
     container = registry.container();
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { singleton: false });
     registry.register('view:toplevel', EmberView.extend());
     registry.register('component-lookup:main', ComponentLookup);
   },

--- a/packages/ember-htmlbars/tests/integration/block_params_test.js
+++ b/packages/ember-htmlbars/tests/integration/block_params_test.js
@@ -22,7 +22,7 @@ QUnit.module("ember-htmlbars: block params", {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
 

--- a/packages/ember-htmlbars/tests/integration/block_params_test.js
+++ b/packages/ember-htmlbars/tests/integration/block_params_test.js
@@ -22,7 +22,6 @@ QUnit.module("ember-htmlbars: block params", {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { singleton: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
 

--- a/packages/ember-htmlbars/tests/integration/component_element_id_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_element_id_test.js
@@ -14,7 +14,7 @@ QUnit.module('ember-htmlbars: component elementId', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
 

--- a/packages/ember-htmlbars/tests/integration/component_element_id_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_element_id_test.js
@@ -14,7 +14,6 @@ QUnit.module('ember-htmlbars: component elementId', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { singleton: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
 

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -16,7 +16,6 @@ function commonSetup() {
   registry.optionsForType('component', { singleton: false });
   registry.optionsForType('view', { singleton: false });
   registry.optionsForType('template', { instantiate: false });
-  registry.optionsForType('helper', { singleton: false });
   registry.register('component-lookup:main', ComponentLookup);
 }
 

--- a/packages/ember-htmlbars/tests/integration/component_invocation_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_invocation_test.js
@@ -16,7 +16,7 @@ function commonSetup() {
   registry.optionsForType('component', { singleton: false });
   registry.optionsForType('view', { singleton: false });
   registry.optionsForType('template', { instantiate: false });
-  registry.optionsForType('helper', { instantiate: false });
+  registry.optionsForType('helper', { singleton: false });
   registry.register('component-lookup:main', ComponentLookup);
 }
 

--- a/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
@@ -17,7 +17,7 @@ QUnit.module('component - lifecycle hooks', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
     registry.register('component-lookup:main', ComponentLookup);
 
     hooks = [];

--- a/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
+++ b/packages/ember-htmlbars/tests/integration/component_lifecycle_test.js
@@ -17,7 +17,6 @@ QUnit.module('component - lifecycle hooks', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { singleton: false });
     registry.register('component-lookup:main', ComponentLookup);
 
     hooks = [];

--- a/packages/ember-htmlbars/tests/integration/mutable_binding_test.js
+++ b/packages/ember-htmlbars/tests/integration/mutable_binding_test.js
@@ -17,7 +17,7 @@ QUnit.module('component - mutable bindings', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
 

--- a/packages/ember-htmlbars/tests/integration/mutable_binding_test.js
+++ b/packages/ember-htmlbars/tests/integration/mutable_binding_test.js
@@ -17,7 +17,6 @@ QUnit.module('component - mutable bindings', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { singleton: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
 

--- a/packages/ember-htmlbars/tests/integration/void-element-component-test.js
+++ b/packages/ember-htmlbars/tests/integration/void-element-component-test.js
@@ -14,7 +14,6 @@ QUnit.module('ember-htmlbars: components for void elements', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { singleton: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
 

--- a/packages/ember-htmlbars/tests/integration/void-element-component-test.js
+++ b/packages/ember-htmlbars/tests/integration/void-element-component-test.js
@@ -14,7 +14,7 @@ QUnit.module('ember-htmlbars: components for void elements', {
     registry.optionsForType('component', { singleton: false });
     registry.optionsForType('view', { singleton: false });
     registry.optionsForType('template', { instantiate: false });
-    registry.optionsForType('helper', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
     registry.register('component-lookup:main', ComponentLookup);
   },
 

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -2,6 +2,7 @@ import lookupHelper, { findHelper } from "ember-htmlbars/system/lookup-helper";
 import ComponentLookup from "ember-views/component_lookup";
 import Registry from "container/registry";
 import Component from "ember-views/views/component";
+import Helper from "ember-htmlbars/helper";
 
 function generateEnv(helpers, container) {
   return {
@@ -15,7 +16,7 @@ function generateContainer() {
   var registry = new Registry();
   var container = registry.container();
 
-  registry.optionsForType('helper', { instantiate: false });
+  registry.optionsForType('helper', { singleton: false });
   registry.register('component-lookup:main', ComponentLookup);
 
   return container;
@@ -64,16 +65,15 @@ QUnit.test('does a lookup in the container if the name contains a dash (and help
     container: container
   };
 
-  function someName() {}
-  someName.isHTMLBars = true;
+  var someName = Helper.extend();
   view.container._registry.register('helper:some-name', someName);
 
   var actual = lookupHelper('some-name', view, env);
 
-  equal(actual, someName, 'does not wrap provided function if `isHTMLBars` is truthy');
+  ok(someName.detectInstance(actual), 'helper is an instance of the helper class');
 });
 
-QUnit.test('wraps helper from container in a Handlebars compat helper', function() {
+QUnit.test('looks up a shorthand helper in the container', function() {
   expect(2);
   var container = generateContainer();
   var env = generateEnv(null, container);
@@ -85,50 +85,13 @@ QUnit.test('wraps helper from container in a Handlebars compat helper', function
   function someName() {
     called = true;
   }
-  view.container._registry.register('helper:some-name', someName);
+  view.container._registry.register('helper:some-name', Helper.build(someName));
 
   var actual = lookupHelper('some-name', view, env);
 
-  ok(actual.isHTMLBars, 'wraps provided helper in an HTMLBars compatible helper');
+  ok(actual.isHelper, 'is a helper');
 
-  var fakeParams = [];
-  var fakeHash = {};
-  var fakeOptions = {
-    morph: { update() { } },
-    template: {},
-    inverse: {}
-  };
-  var fakeEnv = { };
-  var fakeScope = { };
-  actual.helperFunction(fakeParams, fakeHash, fakeOptions, fakeEnv, fakeScope);
+  actual.compute([], {});
 
   ok(called, 'HTMLBars compatible wrapper is wraping the provided function');
-});
-
-QUnit.test('asserts if component-lookup:main cannot be found', function() {
-  var container = generateContainer();
-  var env = generateEnv(null, container);
-  var view = {
-    container: container
-  };
-
-  view.container._registry.unregister('component-lookup:main');
-
-  expectAssertion(function() {
-    lookupHelper('some-name', view, env);
-  }, 'Could not find \'component-lookup:main\' on the provided container, which is necessary for performing component lookups');
-});
-
-QUnit.test('registers a helper in the container if component is found', function() {
-  var container = generateContainer();
-  var env = generateEnv(null, container);
-  var view = {
-    container: container
-  };
-
-  view.container._registry.register('component:some-name', Component);
-
-  lookupHelper('some-name', view, env);
-
-  ok(view.container.lookup('helper:some-name'), 'new helper was registered');
 });

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -69,7 +69,7 @@ QUnit.test('does a lookup in the container if the name contains a dash (and help
 
   var actual = lookupHelper('some-name', view, env);
 
-  ok(someName.detectInstance(actual), 'helper is an instance of the helper class');
+  ok(someName.detect(actual), 'helper is an instance of the helper class');
 });
 
 QUnit.test('looks up a shorthand helper in the container', function() {
@@ -88,7 +88,7 @@ QUnit.test('looks up a shorthand helper in the container', function() {
 
   var actual = lookupHelper('some-name', view, env);
 
-  ok(actual.isHelper, 'is a helper');
+  ok(actual.isHelperInstance, 'is a helper');
 
   actual.compute([], {});
 

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -95,3 +95,19 @@ QUnit.test('looks up a shorthand helper in the container', function() {
 
   ok(called, 'HTMLBars compatible wrapper is wraping the provided function');
 });
+
+QUnit.test('fails with a useful error when resolving a function', function() {
+  expect(1);
+  var container = generateContainer();
+  var env = generateEnv(null, container);
+  var view = {
+    container: container
+  };
+
+  function someName() {}
+  view.container._registry.register('helper:some-name', someName);
+
+  expectAssertion(function() {
+    var actual = lookupHelper('some-name', view, env);
+  }, /The factory for "some-name" is not an Ember helper/);
+});

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -15,7 +15,6 @@ function generateContainer() {
   var registry = new Registry();
   var container = registry.container();
 
-  registry.optionsForType('helper', { singleton: false });
   registry.register('component-lookup:main', ComponentLookup);
 
   return container;

--- a/packages/ember-htmlbars/tests/system/lookup-helper_test.js
+++ b/packages/ember-htmlbars/tests/system/lookup-helper_test.js
@@ -1,7 +1,6 @@
 import lookupHelper, { findHelper } from "ember-htmlbars/system/lookup-helper";
 import ComponentLookup from "ember-views/component_lookup";
 import Registry from "container/registry";
-import Component from "ember-views/views/component";
 import Helper from "ember-htmlbars/helper";
 
 function generateEnv(helpers, container) {
@@ -108,6 +107,6 @@ QUnit.test('fails with a useful error when resolving a function', function() {
   view.container._registry.register('helper:some-name', someName);
 
   expectAssertion(function() {
-    var actual = lookupHelper('some-name', view, env);
+    lookupHelper('some-name', view, env);
   }, /The factory for "some-name" is not an Ember helper/);
 });

--- a/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
@@ -21,7 +21,6 @@ QUnit.module("ember-htmlbars: makeBoundHelper", {
   setup() {
     registry = new Registry();
     container = registry.container();
-    registry.optionsForType('helper', { singleton: false });
   },
 
   teardown() {

--- a/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
@@ -21,7 +21,7 @@ QUnit.module("ember-htmlbars: makeBoundHelper", {
   setup() {
     registry = new Registry();
     container = registry.container();
-    registry.optionsForType('helper', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
   },
 
   teardown() {

--- a/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_bound_helper_test.js
@@ -192,7 +192,7 @@ QUnit.test("bound helpers should not be invoked with blocks", function() {
 
   expectAssertion(function() {
     runAppend(view);
-  }, /makeBoundHelper generated helpers do not support use with blocks/i);
+  }, /Helpers may not be used in the block form/);
 });
 
 QUnit.test("shouldn't treat raw numbers as bound paths", function() {

--- a/packages/ember-htmlbars/tests/system/make_view_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_view_helper_test.js
@@ -10,7 +10,6 @@ QUnit.module("ember-htmlbars: makeViewHelper", {
   setup() {
     registry = new Registry();
     container = registry.container();
-    registry.optionsForType('helper', { singleton: false });
   },
   teardown() {
     runDestroy(view);

--- a/packages/ember-htmlbars/tests/system/make_view_helper_test.js
+++ b/packages/ember-htmlbars/tests/system/make_view_helper_test.js
@@ -10,7 +10,7 @@ QUnit.module("ember-htmlbars: makeViewHelper", {
   setup() {
     registry = new Registry();
     container = registry.container();
-    registry.optionsForType('helper', { instantiate: false });
+    registry.optionsForType('helper', { singleton: false });
   },
   teardown() {
     runDestroy(view);

--- a/packages/ember-views/lib/component_lookup.js
+++ b/packages/ember-views/lib/component_lookup.js
@@ -1,14 +1,10 @@
 import Ember from 'ember-metal/core';
 import EmberObject from "ember-runtime/system/object";
-import { ISNT_HELPER_CACHE } from "ember-htmlbars/system/lookup-helper";
+import { CONTAINS_DASH_CACHE } from "ember-htmlbars/system/lookup-helper";
 
 export default EmberObject.extend({
   invalidName(name) {
-    var invalidName = ISNT_HELPER_CACHE.get(name);
-
-    if (invalidName) {
-      Ember.assert(`You cannot use '${name}' as a component name. Component names must contain a hyphen.`);
-    }
+    Ember.assert(`You cannot use '${name}' as a component name. Component names must contain a hyphen.`, CONTAINS_DASH_CACHE.get(name));
   },
 
   lookupFactory(name, container) {
@@ -37,18 +33,14 @@ export default EmberObject.extend({
   },
 
   componentFor(name, container) {
-    if (this.invalidName(name)) {
-      return;
-    }
+    this.invalidName(name);
 
     var fullName = 'component:' + name;
     return container.lookupFactory(fullName);
   },
 
   layoutFor(name, container) {
-    if (this.invalidName(name)) {
-      return;
-    }
+    this.invalidName(name);
 
     var templateFullName = 'template:components/' + name;
     return container.lookup(templateFullName);

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -122,3 +122,24 @@ QUnit.test("Undashed helpers registered on the container can not (presently) be 
     });
   }, /A helper named 'omg' could not be found/);
 });
+
+QUnit.test("Helpers can receive injections", function() {
+  Ember.TEMPLATES.application = compile("<div id='wrapper'>{{full-name}}</div>");
+
+  var serviceCalled = false;
+  boot(function() {
+    registry.register('service:name-builder', Ember.Service.extend({
+      build() {
+        serviceCalled = true;
+      }
+    }));
+    registry.register('helper:full-name', Ember.Helper.extend({
+      nameBuilder: Ember.inject.service('name-builder'),
+      compute() {
+        this.get('nameBuilder').build();
+      }
+    }));
+  });
+
+  ok(serviceCalled, 'service was injected, method called');
+});

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -1,6 +1,7 @@
 import "ember";
 
 import EmberHandlebars from "ember-htmlbars/compat";
+import HandlebarsCompatibleHelper from "ember-htmlbars/compat/helper";
 
 var compile, helpers, makeBoundHelper;
 compile = EmberHandlebars.compile;
@@ -56,13 +57,13 @@ var boot = function(callback) {
 };
 
 QUnit.test("Unbound dashed helpers registered on the container can be late-invoked", function() {
+  Ember.TEMPLATES.application = compile("<div id='wrapper'>{{x-borf}} {{x-borf 'YES'}}</div>");
+  let helper = new HandlebarsCompatibleHelper((val) => {
+    return arguments.length > 1 ? val : "BORF";
+  });
 
-  Ember.TEMPLATES.application = compile("<div id='wrapper'>{{x-borf}} {{x-borf YES}}</div>");
-
-  boot(function() {
-    registry.register('helper:x-borf', function(val) {
-      return arguments.length > 1 ? val : "BORF";
-    });
+  boot(() => {
+    registry.register('helper:x-borf', helper);
   });
 
   equal(Ember.$('#wrapper').text(), "BORF YES", "The helper was invoked from the container");

--- a/packages/ember/tests/helpers/helper_registration_test.js
+++ b/packages/ember/tests/helpers/helper_registration_test.js
@@ -58,7 +58,7 @@ var boot = function(callback) {
 
 QUnit.test("Unbound dashed helpers registered on the container can be late-invoked", function() {
   Ember.TEMPLATES.application = compile("<div id='wrapper'>{{x-borf}} {{x-borf 'YES'}}</div>");
-  let helper = new HandlebarsCompatibleHelper((val) => {
+  let helper = new HandlebarsCompatibleHelper(function(val) {
     return arguments.length > 1 ? val : "BORF";
   });
 


### PR DESCRIPTION
If a helper is linked, it must trigger rerender of the view it is attached to if it is marked invalid.

There may be a better way to do this. Invalidating the stream alone not longer causes updates as before.

See also: https://github.com/tildeio/htmlbars/pull/358

Contains one known failing test: `ember-htmlbars: custom app helpers: dashed helper used in subexpression is destroyed`